### PR TITLE
fix: Dynamic zone duplication for nested relations and components

### DIFF
--- a/admin/src/components/DynamicZoneActionInjector.mjs
+++ b/admin/src/components/DynamicZoneActionInjector.mjs
@@ -1,10 +1,22 @@
 import React from 'react';
-import { useNotification } from '@strapi/admin/strapi-admin';
-import { unstable_useContentManagerContext as useContentManagerContext } from '@strapi/content-manager/strapi-admin';
+import { useFetchClient, useNotification, useQueryParams } from '@strapi/admin/strapi-admin';
+import {
+  buildValidParams,
+  unstable_useContentManagerContext as useContentManagerContext,
+} from '@strapi/content-manager/strapi-admin';
 import { useIntl } from 'react-intl';
 
 const DUPLICATE_CONTAINER_ATTR = 'data-dz-component-duplicator-action';
 const INDEX_SEGMENT_REGEX = /^\d+$/;
+const COLLECTION_TYPES = 'collection-types';
+const SINGLE_TYPES = 'single-types';
+const ONE_WAY_RELATIONS = new Set([
+  'oneWay',
+  'oneToOne',
+  'manyToOne',
+  'oneToManyMorph',
+  'oneToOneMorph',
+]);
 const DUPLICATE_ICON_PATH =
   'M27 4H11a1 1 0 0 0-1 1v5H5a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h16a1 1 0 0 0 1-1v-5h5a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1m-1 16h-4v-9a1 1 0 0 0-1-1h-9V6h14z';
 
@@ -44,6 +56,10 @@ const isDynamicZoneItem = (value) => {
   return isPlainObject(value) && typeof value.__component === 'string';
 };
 
+const isMediaObject = (value) => {
+  return isPlainObject(value) && typeof value.mime === 'string';
+};
+
 const collectDynamicZonePaths = (value, currentPath = '', acc = []) => {
   if (Array.isArray(value)) {
     if (currentPath && value.length > 0 && value.every(isDynamicZoneItem)) {
@@ -78,36 +94,14 @@ const cloneValue = (value) => {
   return JSON.parse(JSON.stringify(value));
 };
 
-const isMediaObject = (value) => {
-  return isPlainObject(value) && typeof value.mime === 'string';
-};
+const createTempKeyFactory = () => {
+  let counter = 0;
+  const seed =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 
-const stripTransientKeys = (value) => {
-  if (Array.isArray(value)) {
-    return value.map(stripTransientKeys);
-  }
-
-  if (!isPlainObject(value)) {
-    return value;
-  }
-
-  // Media references must keep their id/documentId so Strapi can
-  // maintain the relation on save.
-  if (isMediaObject(value)) {
-    return value;
-  }
-
-  const next = {};
-
-  for (const [key, nested] of Object.entries(value)) {
-    if (key === 'id' || key === 'documentId' || key === '__temp_key__') {
-      continue;
-    }
-
-    next[key] = stripTransientKeys(nested);
-  }
-
-  return next;
+  return () => `${String(counter++).padStart(4, '0')}-${seed}`;
 };
 
 const getActionAnchor = (listItem) => {
@@ -117,10 +111,6 @@ const getActionAnchor = (listItem) => {
     return null;
   }
 
-  // Dynamic zone headers include a drag handle, a delete button, and a
-  // more-actions menu.  We look for the drag button by its aria-label and
-  // fall back to verifying that at least three buttons exist (the minimum
-  // for a dynamic zone header as of Strapi 5).
   const dragButton =
     header.querySelector('button[aria-label="Drag"]') ||
     header.querySelector('button[aria-label="drag"]');
@@ -258,35 +248,425 @@ const createDuplicateButton = (anchor, label, onClick, signal) => {
 
   const textTemplate = anchor.querySelector('span');
   const text = document.createElement('span');
+
   if (textTemplate?.className) {
     text.className = textTemplate.className;
   }
   text.textContent = label;
 
   button.append(icon, text);
-  button.addEventListener('click', (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    onClick();
-  }, { signal });
+  button.addEventListener(
+    'click',
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      void onClick();
+    },
+    { signal }
+  );
 
   return button;
+};
+
+const getRelationIdentity = (relation) => {
+  if (!isPlainObject(relation)) {
+    return null;
+  }
+
+  const documentId = relation.documentId ?? relation.apiData?.documentId;
+  const locale = relation.locale ?? relation.apiData?.locale ?? '';
+  const id = relation.id ?? relation.apiData?.id;
+
+  if (documentId) {
+    return `${documentId}::${locale}`;
+  }
+
+  if (id !== null && id !== undefined) {
+    return `id:${id}`;
+  }
+
+  return null;
+};
+
+const getRelationDisplayValue = (relation) => {
+  const candidateKeys = [
+    'label',
+    'title',
+    'name',
+    'displayName',
+    'question',
+    'heading',
+    'slug',
+    'documentId',
+    'id',
+  ];
+
+  for (const key of candidateKeys) {
+    const value = relation?.[key];
+
+    if (typeof value === 'string' && value.trim()) {
+      return value;
+    }
+
+    if (typeof value === 'number') {
+      return String(value);
+    }
+  }
+
+  return '';
+};
+
+const getRelationCollectionType = (targetModel, contentTypes) => {
+  const targetSchema = Array.isArray(contentTypes)
+    ? contentTypes.find((schema) => schema?.uid === targetModel)
+    : null;
+
+  return targetSchema?.kind === 'singleType' ? SINGLE_TYPES : COLLECTION_TYPES;
+};
+
+const getRelationHref = (targetModel, contentTypes, documentId, locale) => {
+  if (!targetModel || !documentId) {
+    return undefined;
+  }
+
+  const collectionType = getRelationCollectionType(targetModel, contentTypes);
+  const basePath =
+    collectionType === SINGLE_TYPES
+      ? `../${SINGLE_TYPES}/${targetModel}`
+      : `../${COLLECTION_TYPES}/${targetModel}/${documentId}`;
+
+  return locale ? `${basePath}?plugins[i18n][locale]=${locale}` : basePath;
+};
+
+const normalizeFetchedRelations = (value) => {
+  if (Array.isArray(value)) {
+    return value.filter(isPlainObject);
+  }
+
+  if (isPlainObject(value) && Array.isArray(value.results)) {
+    return value.results.filter(isPlainObject);
+  }
+
+  if (isPlainObject(value)) {
+    return [value];
+  }
+
+  return [];
+};
+
+const toRelationConnectEntry = (relation, attribute, contentTypes, createTempKey) => {
+  if (!isPlainObject(relation)) {
+    return null;
+  }
+
+  const id = relation.id ?? relation.apiData?.id;
+  const documentId = relation.documentId ?? relation.apiData?.documentId;
+  const locale = relation.locale ?? relation.apiData?.locale ?? null;
+  const label = relation.label ?? getRelationDisplayValue(relation);
+  const href = relation.href ?? getRelationHref(attribute.target, contentTypes, documentId, locale);
+  const next = {
+    id,
+    documentId,
+    locale,
+    href,
+    label: label || documentId || (id !== undefined && id !== null ? String(id) : ''),
+    __temp_key__: createTempKey(),
+    apiData: {
+      id,
+      documentId: documentId ?? '',
+      locale,
+      isTemporary: relation.apiData?.isTemporary ?? true,
+    },
+  };
+
+  if (relation.status !== undefined) {
+    next.status = relation.status;
+  } else if (typeof relation.publishedAt === 'string') {
+    next.status = 'published';
+  }
+
+  return next;
+};
+
+const sanitizeRelationValue = async ({
+  attribute,
+  value,
+  sourceContext,
+  fieldName,
+  contentTypes,
+  createTempKey,
+  fetchRelationItems,
+}) => {
+  const currentConnect = Array.isArray(value?.connect) ? value.connect : [];
+  const currentDisconnect = Array.isArray(value?.disconnect) ? value.disconnect : [];
+  const fetchedRelations =
+    sourceContext?.id && sourceContext?.model
+      ? await fetchRelationItems(sourceContext.model, sourceContext.id, fieldName)
+      : [];
+
+  const connectedByIdentity = new Map();
+
+  for (const relation of currentConnect) {
+    const entry = toRelationConnectEntry(relation, attribute, contentTypes, createTempKey);
+    const identity = getRelationIdentity(entry);
+
+    if (entry && identity) {
+      connectedByIdentity.set(identity, entry);
+    }
+  }
+
+  const disconnectedIdentities = new Set(
+    currentDisconnect.map(getRelationIdentity).filter(Boolean)
+  );
+
+  const effectiveRelations = [];
+
+  for (const relation of fetchedRelations) {
+    const entry = toRelationConnectEntry(relation, attribute, contentTypes, createTempKey);
+    const identity = getRelationIdentity(entry);
+
+    if (!entry || !identity || disconnectedIdentities.has(identity)) {
+      continue;
+    }
+
+    if (connectedByIdentity.has(identity)) {
+      effectiveRelations.push(connectedByIdentity.get(identity));
+      connectedByIdentity.delete(identity);
+      continue;
+    }
+
+    effectiveRelations.push(entry);
+  }
+
+  for (const relation of connectedByIdentity.values()) {
+    effectiveRelations.push(relation);
+  }
+
+  const connect = ONE_WAY_RELATIONS.has(attribute.relation)
+    ? effectiveRelations.slice(-1)
+    : effectiveRelations;
+
+  return {
+    connect,
+    disconnect: [],
+  };
+};
+
+const sanitizeComponentValue = async ({
+  value,
+  componentUid,
+  components,
+  contentTypes,
+  createTempKey,
+  fetchRelationItems,
+  sourceContext,
+}) => {
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const attributes = components?.[componentUid]?.attributes ?? {};
+  const next = {};
+
+  for (const [fieldName, attribute] of Object.entries(attributes)) {
+    if (!(fieldName in value)) {
+      continue;
+    }
+
+    next[fieldName] = await sanitizeAttributeValue({
+      attribute,
+      fieldName,
+      value: value[fieldName],
+      components,
+      contentTypes,
+      createTempKey,
+      fetchRelationItems,
+      sourceContext: {
+        model: componentUid,
+        id: sourceContext?.id ?? value?.id,
+      },
+    });
+  }
+
+  return next;
+};
+
+const sanitizeDynamicZoneValue = async ({
+  value,
+  components,
+  contentTypes,
+  createTempKey,
+  fetchRelationItems,
+}) => {
+  if (!isDynamicZoneItem(value)) {
+    return value;
+  }
+
+  const componentUid = value.__component;
+  const next = await sanitizeComponentValue({
+    value,
+    componentUid,
+    components,
+    contentTypes,
+    createTempKey,
+    fetchRelationItems,
+    sourceContext: {
+      model: componentUid,
+      id: value?.id,
+    },
+  });
+
+  return {
+    __component: componentUid,
+    ...next,
+  };
+};
+
+const sanitizeAttributeValue = async ({
+  attribute,
+  fieldName,
+  value,
+  components,
+  contentTypes,
+  createTempKey,
+  fetchRelationItems,
+  sourceContext,
+}) => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (attribute.type === 'component') {
+    if (attribute.repeatable) {
+      if (!Array.isArray(value)) {
+        return [];
+      }
+
+      const next = await Promise.all(
+        value.map((item) =>
+          sanitizeComponentValue({
+            value: item,
+            componentUid: attribute.component,
+            components,
+            contentTypes,
+            createTempKey,
+            fetchRelationItems,
+            sourceContext: {
+              model: attribute.component,
+              id: item?.id,
+            },
+          })
+        )
+      );
+
+      return next.map((item) =>
+        isPlainObject(item)
+          ? {
+              ...item,
+              __temp_key__: createTempKey(),
+            }
+          : item
+      );
+    }
+
+    return sanitizeComponentValue({
+      value,
+      componentUid: attribute.component,
+      components,
+      contentTypes,
+      createTempKey,
+      fetchRelationItems,
+      sourceContext: {
+        model: attribute.component,
+        id: value?.id,
+      },
+    });
+  }
+
+  if (attribute.type === 'dynamiczone') {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    const next = await Promise.all(
+      value.map((item) =>
+        sanitizeDynamicZoneValue({
+          value: item,
+          components,
+          contentTypes,
+          createTempKey,
+          fetchRelationItems,
+        })
+      )
+    );
+
+    return next.map((item) =>
+      isPlainObject(item)
+        ? {
+            ...item,
+            __temp_key__: createTempKey(),
+          }
+        : item
+    );
+  }
+
+  if (attribute.type === 'relation') {
+    return sanitizeRelationValue({
+      attribute,
+      value,
+      sourceContext,
+      fieldName,
+      contentTypes,
+      createTempKey,
+      fetchRelationItems,
+    });
+  }
+
+  if (attribute.type === 'media') {
+    return cloneValue(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneValue(item));
+  }
+
+  if (isPlainObject(value)) {
+    if (isMediaObject(value)) {
+      return cloneValue(value);
+    }
+
+    return cloneValue(value);
+  }
+
+  return value;
 };
 
 const DynamicZoneActionInjector = () => {
   const { formatMessage } = useIntl();
   const { toggleNotification } = useNotification();
-  const { form, isLoading, components } = useContentManagerContext();
+  const { get } = useFetchClient();
+  const [{ query }] = useQueryParams();
+  const { form, isLoading, components, contentTypes, model, collectionType, id } =
+    useContentManagerContext();
 
   const isBrowser = typeof document !== 'undefined';
-
   const values = form?.values;
   const valuesRef = React.useRef(values);
   const observerRef = React.useRef(null);
   const frameRef = React.useRef(0);
   const abortRef = React.useRef(null);
+  const relationCacheRef = React.useRef(new Map());
 
   valuesRef.current = values;
+
+  const relationQueryParams = React.useMemo(() => {
+    const params = buildValidParams(query ?? {});
+
+    return {
+      locale: params?.locale,
+      status: params?.status,
+    };
+  }, [query]);
 
   const duplicateLabel = formatMessage({
     id: 'strapi-dz-component-duplicator.action.duplicate',
@@ -297,6 +677,71 @@ const DynamicZoneActionInjector = () => {
     id: 'strapi-dz-component-duplicator.error.duplicate',
     defaultMessage: 'Could not duplicate this component.',
   });
+
+  const fetchRelationItems = React.useCallback(
+    async (relationModel, relationId, fieldName) => {
+      if (!relationModel || !relationId || !fieldName) {
+        return [];
+      }
+
+      const cacheKey = JSON.stringify({
+        relationModel,
+        relationId,
+        fieldName,
+        relationQueryParams,
+      });
+
+      const cachedPromise = relationCacheRef.current.get(cacheKey);
+
+      if (cachedPromise) {
+        return cachedPromise;
+      }
+
+      const request = (async () => {
+        let page = 1;
+        let totalPages = 1;
+        const relations = [];
+
+        while (page <= totalPages) {
+          const response = await get(
+            `/content-manager/relations/${relationModel}/${relationId}/${fieldName}`,
+            {
+              params: {
+                ...relationQueryParams,
+                page,
+                pageSize: 100,
+              },
+            }
+          );
+          const payload = response?.data ?? {};
+          const pageResults = normalizeFetchedRelations(payload.results).reverse();
+
+          relations.push(...pageResults);
+
+          const pagination = payload?.pagination;
+          const pageCount =
+            typeof pagination?.pageCount === 'number'
+              ? pagination.pageCount
+              : Math.max(1, Math.ceil((pagination?.total ?? pageResults.length) / 100));
+
+          totalPages = pageCount;
+          page += 1;
+        }
+
+        return relations;
+      })();
+
+      relationCacheRef.current.set(cacheKey, request);
+
+      try {
+        return await request;
+      } catch (error) {
+        relationCacheRef.current.delete(cacheKey);
+        throw error;
+      }
+    },
+    [get, relationQueryParams]
+  );
 
   const cleanupInjectedButtons = React.useCallback(() => {
     if (abortRef.current) {
@@ -311,7 +756,7 @@ const DynamicZoneActionInjector = () => {
   }, []);
 
   const handleDuplicate = React.useCallback(
-    (dynamicZonePath, index) => {
+    async (dynamicZonePath, index) => {
       if (!form || typeof form.addFieldRow !== 'function') {
         return;
       }
@@ -323,7 +768,20 @@ const DynamicZoneActionInjector = () => {
       }
 
       try {
-        const cloned = stripTransientKeys(cloneValue(item));
+        relationCacheRef.current.clear();
+        const createTempKey = createTempKeyFactory();
+        const cloned = await sanitizeDynamicZoneValue({
+          value: item,
+          components,
+          contentTypes,
+          createTempKey,
+          fetchRelationItems,
+        });
+
+        if (!isDynamicZoneItem(cloned)) {
+          throw new Error('Invalid dynamic zone clone');
+        }
+
         form.addFieldRow(dynamicZonePath, cloned, index + 1);
       } catch {
         toggleNotification({
@@ -332,7 +790,14 @@ const DynamicZoneActionInjector = () => {
         });
       }
     },
-    [form, toggleNotification, duplicateErrorLabel]
+    [
+      components,
+      contentTypes,
+      duplicateErrorLabel,
+      fetchRelationItems,
+      form,
+      toggleNotification,
+    ]
   );
 
   const injectButtons = React.useCallback(() => {
@@ -379,13 +844,13 @@ const DynamicZoneActionInjector = () => {
         continue;
       }
 
-      const duplicateButton = createDuplicateButton(anchor, duplicateLabel, () => {
-        handleDuplicate(location.dynamicZonePath, location.index);
-      }, controller.signal);
-      anchor.parentElement.insertBefore(
-        duplicateButton,
-        anchor
+      const duplicateButton = createDuplicateButton(
+        anchor,
+        duplicateLabel,
+        () => handleDuplicate(location.dynamicZonePath, location.index),
+        controller.signal
       );
+      anchor.parentElement.insertBefore(duplicateButton, anchor);
     }
 
     if (observer) {
@@ -395,6 +860,10 @@ const DynamicZoneActionInjector = () => {
       });
     }
   }, [cleanupInjectedButtons, components, duplicateLabel, handleDuplicate, isBrowser, isLoading]);
+
+  React.useEffect(() => {
+    relationCacheRef.current.clear();
+  }, [id, model, collectionType, relationQueryParams]);
 
   React.useEffect(() => {
     if (!isBrowser) {


### PR DESCRIPTION
Fixes for:
- [Can't open sub components after duplicating](https://github.com/djordjesavanovic/strapi-dz-component-duplicator/issues/1)
- [If a duplicated component had a relation inside, it is not set for the duplicated component unfortunately.](https://github.com/djordjesavanovic/strapi-dz-component-duplicator/issues/2)

---

## Summary

Improves dynamic zone duplication in the Strapi admin by properly sanitizing duplicated component data before insertion.

Previously, duplication mostly relied on deep cloning and stripping transient keys. That worked for simple cases, but caused issues for more complex nested structures, especially relations, repeatable components, dynamic zones, and localized relation data.

This change introduces a schema-aware sanitization flow so duplicated dynamic zone entries are recreated in a form state shape that Strapi can save correctly.

## What changed

* added schema-aware duplication logic for:

  * components
  * repeatable components
  * nested dynamic zones
  * relations
  * media fields

* replaced the old `stripTransientKeys` approach with recursive sanitizers:

  * `sanitizeAttributeValue`
  * `sanitizeComponentValue`
  * `sanitizeDynamicZoneValue`
  * `sanitizeRelationValue`

* preserved media references during duplication instead of stripping required identifiers

* added temporary key generation via `createTempKeyFactory()` so duplicated nested items receive stable fresh `__temp_key__` values

* added relation normalization helpers to support correct duplication of connected relations:

  * relation identity resolution
  * relation label/display value resolution
  * relation href generation
  * fetched relation normalization
  * connect-entry transformation

* added fetching of relation items through `useFetchClient()` for cases where the form value alone is not enough to reconstruct the duplicated relation state correctly

* added relation request caching to avoid repeated requests during a single duplication flow

* included locale/status-aware relation fetching using `useQueryParams()` + `buildValidParams()`

* updated duplicate button click handling to support async duplication safely

## Why

Duplicating dynamic zone components with nested relational content could produce invalid or incomplete form data.

In particular:

* relation fields were not always recreated in the expected `connect/disconnect` structure
* one-way style relations needed special handling to keep only the effective final relation
* nested components/dynamic zones needed fresh temporary keys
* media objects needed to retain their identifiers
* localized relation links needed the correct locale/status context

This PR makes duplication behave much closer to how Strapi expects edited content to exist in the form state, reducing save failures and broken duplicated blocks.

## Technical notes

* relation fetching is cached per model/id/field/query params combination
* cache is cleared when the current entry context changes (`id`, `model`, `collectionType`, locale/status query params)
* one-way-like relations are collapsed to the last effective connected entry
* fetched relation results are merged with existing `connect/disconnect` state to preserve the effective selection

## Result

Duplicating a dynamic zone block now works more reliably for complex content structures, including nested components and relations, while preserving valid Strapi form state for saving.
