### PR TITLE
fix: DynamicZoneActionInjector to improve attribute handling

### DIFF
--- a/admin/src/components/DynamicZoneActionInjector.mjs
+++ b/admin/src/components/DynamicZoneActionInjector.mjs
@@ -780,13 +780,6 @@ const DynamicZoneActionInjector = () => {
           throw new Error('Invalid dynamic zone clone');
         }
 
-        console.group('[DZ-Duplicator] Duplicate Debug');
-        console.log('Original item:', JSON.parse(JSON.stringify(item)));
-        console.log('Cloned item (before addFieldRow):', JSON.parse(JSON.stringify(cloned)));
-        console.log('Inserting at path:', dynamicZonePath, 'position:', index + 1);
-        console.log('Current DZ length:', getIn(valuesRef.current, dynamicZonePath)?.length);
-        console.groupEnd();
-
         form.addFieldRow(dynamicZonePath, cloned, index + 1);
       } catch {
         toggleNotification({

--- a/admin/src/components/DynamicZoneActionInjector.mjs
+++ b/admin/src/components/DynamicZoneActionInjector.mjs
@@ -373,9 +373,7 @@ const toRelationConnectEntry = (relation, attribute, contentTypes, createTempKey
     __temp_key__: createTempKey(),
     apiData: {
       id,
-      documentId: documentId ?? '',
       locale,
-      isTemporary: relation.apiData?.isTemporary ?? true,
     },
   };
 
@@ -469,7 +467,7 @@ const sanitizeComponentValue = async ({
   const next = {};
 
   for (const [fieldName, attribute] of Object.entries(attributes)) {
-    if (!(fieldName in value)) {
+    if (fieldName === 'id' || !(fieldName in value)) {
       continue;
     }
 
@@ -781,6 +779,13 @@ const DynamicZoneActionInjector = () => {
         if (!isDynamicZoneItem(cloned)) {
           throw new Error('Invalid dynamic zone clone');
         }
+
+        console.group('[DZ-Duplicator] Duplicate Debug');
+        console.log('Original item:', JSON.parse(JSON.stringify(item)));
+        console.log('Cloned item (before addFieldRow):', JSON.parse(JSON.stringify(cloned)));
+        console.log('Inserting at path:', dynamicZonePath, 'position:', index + 1);
+        console.log('Current DZ length:', getIn(valuesRef.current, dynamicZonePath)?.length);
+        console.groupEnd();
 
         form.addFieldRow(dynamicZonePath, cloned, index + 1);
       } catch {


### PR DESCRIPTION
## Summary

This PR adjusts the dynamic zone duplication flow to avoid carrying over persisted identity fields during cloning and adds temporary debug logging around duplicate insertion.

## Changes

- Removed `documentId` from duplicated relation `apiData`
- Removed `isTemporary` from duplicated relation `apiData`
- Skipped copying `id` inside `sanitizeComponentValue`
- Added debug logs before inserting the cloned dynamic zone item

## Why

When duplicating dynamic zone entries, persisted identifiers should not be copied into the cloned item. Keeping fields like `id` or `documentId` can cause the duplicated entry to be treated as an existing entity instead of a new one, which may lead to invalid clone behavior or persistence issues.

This change ensures duplicated components are sanitized more aggressively so they behave like fresh entries.

## Implementation details

### Relation sanitization
In `toRelationConnectEntry`, the cloned relation payload no longer includes:

- `documentId`
- `isTemporary`

Only the minimal relation data needed for the duplicated entry is preserved.

### Component sanitization
In `sanitizeComponentValue`, the `id` field is now explicitly skipped:

```js
if (fieldName === 'id' || !(fieldName in value)) {
  continue;
}
```

This prevents cloned component values from retaining original entity IDs.

### Debug logging
Added grouped console logs in the duplicate flow to inspect:

- the original item
- the cloned item before insertion
- the insertion path and position
- the current dynamic zone length

This should help verify the clone payload during debugging.

## Expected result

Duplicating a dynamic zone item should now insert a clean cloned entry without reusing original persisted identifiers, reducing the risk of invalid clone state or update/create confusion.
