### PR TITLE
fix: Update react-intl version range in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@strapi/strapi": "^5.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-intl": "^7.0.0"
+    "react-intl": "^6.0.0 || ^7.0.0"
   },
   "strapi": {
     "name": "strapi-dz-component-duplicator",


### PR DESCRIPTION
## Summary
- Widen `react-intl` peer dependency from `^7.0.0` to `^6.0.0 || ^7.0.0` to resolve `ERESOLVE` install failure on Strapi 5 projects

## Problem
Strapi 5 (tested on v5.40.0) ships `react-intl@6.6.2`. The plugin declared `react-intl@^7.0.0` as a peer dependency, causing `npm install` to fail with a dependency conflict. Users had to manually add `react-intl@7` to their own `package.json` or use `--legacy-peer-deps` to work around it.

## Fix
The plugin only uses `useIntl` from react-intl, which has an identical API in both v6 and v7. The peer dependency range is widened to accept both major versions.
